### PR TITLE
Add drive confirmation prompt

### DIFF
--- a/Installwizard.cpp
+++ b/Installwizard.cpp
@@ -34,6 +34,18 @@ Installwizard::Installwizard(QWidget *parent) :
             QMessageBox::warning(this, "Error", "Please select a valid drive.");
             return;
         }
+
+        QMessageBox::StandardButton confirm = QMessageBox::question(
+            this,
+            tr("Confirm Drive"),
+            tr("You are about to destroy all data on %1!!! Are you absolutely "
+               "sure this is correct?")
+                .arg(selectedDrive),
+            QMessageBox::Yes | QMessageBox::No);
+
+        if (confirm != QMessageBox::Yes)
+            return;
+
         // Remove "/dev/" prefix for internal processing
         prepareDrive(selectedDrive.mid(5));
     });


### PR DESCRIPTION
## Summary
- ask for confirmation before preparing the selected drive

## Testing
- `qmake ArchHelp.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1d81a52483329233e3dac0480c4e