### PR TITLE
Add EFI partitioning option

### DIFF
--- a/Installwizard.cpp
+++ b/Installwizard.cpp
@@ -34,6 +34,19 @@ Installwizard::Installwizard(QWidget *parent) :
             QMessageBox::warning(this, "Error", "Please select a valid drive.");
             return;
         }
+
+        QMessageBox::StandardButton confirm = QMessageBox::question(
+            this,
+            tr("Confirm Drive"),
+            tr("You are about to destroy all data on %1!!! Are you absolutely "
+               "sure this is correct?")
+                .arg(selectedDrive),
+            QMessageBox::Yes | QMessageBox::No);
+
+        if (confirm != QMessageBox::Yes)
+            return;
+
+        efiInstall = false; // legacy mode
         // Remove "/dev/" prefix for internal processing
         prepareDrive(selectedDrive.mid(5));
     });
@@ -73,7 +86,7 @@ Installwizard::Installwizard(QWidget *parent) :
     connect(ui->createPartButton, &QPushButton::clicked, this, [this]() {
         QString drive = ui->driveDropdown->currentText().mid(5);
         if (!drive.isEmpty())
-            createDefaultPartitions(drive);
+            prepareForEfi(drive);
     });
 
     connect(ui->driveDropdown, &QComboBox::currentTextChanged, this, [this](const QString &text) {
@@ -387,16 +400,56 @@ void Installwizard::populatePartitionTable(const QString &drive) {
     }
 }
 
-void Installwizard::createDefaultPartitions(const QString &drive) {
+void Installwizard::prepareForEfi(const QString &drive) {
+    efiInstall = true; // remember choice for grub
     unmountDrive(drive);
+
     QProcess process;
     QString device = QString("/dev/%1").arg(drive);
+
+    // Determine next free region using parted
+    process.start("/usr/sbin/parted", QStringList() << "-sm" << device << "unit" << "MiB" << "print" << "free");
+    process.waitForFinished();
+    QString out = process.readAllStandardOutput();
+
+    double freeStart = -1, freeEnd = -1;
+    int maxPart = 0;
+    for (const QString &line : out.split('\n', Qt::SkipEmptyParts)) {
+        QString trimmed = line.trimmed();
+        QStringList cols = trimmed.split(':');
+        if (cols.size() < 2)
+            continue;
+
+        bool ok = false;
+        int num = cols[0].toInt(&ok);
+        if (ok)
+            maxPart = std::max(maxPart, num);
+
+        if (trimmed.contains("free", Qt::CaseInsensitive) && cols.size() >= 3) {
+            double start = cols[1].remove(QRegularExpression("[^0-9.]")).toDouble();
+            double end = cols[2].remove(QRegularExpression("[^0-9.]")).toDouble();
+            if (end - start > 1000) { // choose space >1GiB
+                freeStart = start;
+                freeEnd = end;
+                break;
+            }
+        }
+    }
+
+    if (freeStart < 0) {
+        QMessageBox::critical(this, "Partition Error", "No suitable free space found.");
+        return;
+    }
+
+    double bootStart = freeStart + 1;          // align
+    double bootEnd = bootStart + 512;           // 512MiB ESP
+    double rootStart = bootEnd;
+    double rootEnd = freeEnd;
+
     QStringList cmds = {
-        // Legacy BIOS layout: boot partition + root partition
-        QString("sudo parted %1 --script mklabel msdos").arg(device),
-        QString("sudo parted %1 --script mkpart primary ext4 1MiB 513MiB").arg(device),
-        QString("sudo parted %1 --script set 1 boot on").arg(device),
-        QString("sudo parted %1 --script mkpart primary ext4 513MiB 100%").arg(device)
+        QString("sudo parted %1 --script mkpart ESP fat32 %2MiB %3MiB").arg(device).arg(bootStart).arg(bootEnd),
+        QString("sudo parted %1 --script set %2 esp on").arg(device).arg(maxPart + 1),
+        QString("sudo parted %1 --script mkpart primary ext4 %2MiB %3MiB").arg(device).arg(rootStart).arg(rootEnd)
     };
 
     for (const QString &cmd : cmds) {
@@ -410,7 +463,6 @@ void Installwizard::createDefaultPartitions(const QString &drive) {
         }
     }
 
-    // Ensure kernel sees new table
     process.start("/bin/bash", QStringList()
                                 << "-c"
                                 << QString("sudo partprobe %1 && sudo udevadm settle")
@@ -670,13 +722,13 @@ void Installwizard::installGrub(const QString &drive) {
                                   "bash", "-c", "echo 'GRUB_DISABLE_LINUX_UUID=\"false\"' >> /etc/default/grub"
                               });
 
-    // Run grub-install inside chroot
-    int grubRet = QProcess::execute("sudo", {
-                                                "arch-chroot", "/mnt",
-                                                "grub-install",
-                                                "--target=i386-pc",
-                                                disk
-                                            });
+    QStringList grubArgs = {"arch-chroot", "/mnt", "grub-install"};
+    if (efiInstall) {
+        grubArgs << "--target=x86_64-efi" << "--efi-directory=/boot" << "--bootloader-id=GRUB";
+    } else {
+        grubArgs << "--target=i386-pc" << disk;
+    }
+    int grubRet = QProcess::execute("sudo", grubArgs);
     if (grubRet != 0) {
         QMessageBox::critical(nullptr, "Error", "grub-install failed.");
         return;
@@ -733,7 +785,7 @@ void Installwizard::on_installButton_clicked() {
     }
 
     SystemWorker *worker = new SystemWorker;
-    worker->setParameters(selectedDrive, username, password, rootPassword, desktopEnv);
+    worker->setParameters(selectedDrive, username, password, rootPassword, desktopEnv, efiInstall);
 
 
     QThread *thread = new QThread;

--- a/Installwizard.h
+++ b/Installwizard.h
@@ -25,6 +25,7 @@ private:
     QProgressBar *progressBar;
     QNetworkAccessManager *networkManager;
     QString selectedDrive;  // 🧠 TRACK THE CURRENT DRIVE
+    bool efiInstall = false; // track chosen boot mode
     QString getUserHome();
     void populateDrives(); // Populate the dropdown with available drives
     void downloadISO(QProgressBar *progressBar);
@@ -36,7 +37,7 @@ private:
     QStringList getAvailableDrives();        // Detect available drives
     void prepareDrive(const QString &drive);   // Prepare the selected drive
     void populatePartitionTable(const QString &drive); // new
-    void createDefaultPartitions(const QString &drive); // new example
+    void prepareForEfi(const QString &drive); // use free space for EFI
     void mountPartitions(const QString &drive);
     void mountISO();
     void installArchBase(const QString &selectedDrive);

--- a/Installwizard.ui
+++ b/Installwizard.ui
@@ -169,7 +169,7 @@
      </rect>
     </property>
     <property name="text">
-     <string>Create Default Partitions</string>
+     <string>Prepare For EFI</string>
     </property>
    </widget>
    <widget class="QLabel" name="label_5">

--- a/systemworker.h
+++ b/systemworker.h
@@ -14,7 +14,8 @@ public:
                        const QString &username,
                        const QString &password,
                        const QString &rootPassword,
-                       const QString &desktopEnv);
+                       const QString &desktopEnv,
+                       bool useEfi);
 
 signals:
     void logMessage(const QString &msg);
@@ -30,6 +31,7 @@ private:
     QString password;
     QString rootPassword;
     QString desktopEnv;
+    bool useEfi = false;
 
     bool runCommand(const QString &cmd);
 };


### PR DESCRIPTION
## Summary
- track boot mode (legacy vs EFI)
- add `prepareForEfi` to create partitions in free space
- rename the button text to **Prepare For EFI**
- pass boot mode flag to `SystemWorker`
- use the flag when running `grub-install`

## Testing
- `qmake ArchHelp.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1d81a52483329233e3dac0480c4e