### PR TITLE
Fix parted command for EFI

### DIFF
--- a/Installwizard.cpp
+++ b/Installwizard.cpp
@@ -521,7 +521,8 @@ void Installwizard::prepareForEfi(const QString &drive) {
     double rootEnd = freeEnd;
 
     QStringList cmds = {
-        QString("sudo parted %1 --script mkpart ESP fat32 %2MiB %3MiB").arg(device).arg(bootStart).arg(bootEnd),
+        QString("sudo parted %1 --script mkpart primary fat32 %2MiB %3MiB").arg(device).arg(bootStart).arg(bootEnd),
+        QString("sudo parted %1 --script name %2 ESP").arg(device).arg(maxPart + 1),
         QString("sudo parted %1 --script set %2 esp on").arg(device).arg(maxPart + 1),
         QString("sudo parted %1 --script mkpart primary ext4 %2MiB %3MiB").arg(device).arg(rootStart).arg(rootEnd)
     };


### PR DESCRIPTION
## Summary
- correct parted syntax for ESP creation to avoid invalid token error

## Testing
- `qmake ArchHelp.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c95e17e348332a0779ae11650ed59