### PR TITLE
Fix EFI prep button wiring and cleanup

### DIFF
--- a/Installwizard.cpp
+++ b/Installwizard.cpp
@@ -102,34 +102,14 @@ Installwizard::Installwizard(QWidget *parent) :
         if (!drive.isEmpty()) {
             setWizardButtonEnabled(QWizard::NextButton, false);
             prepareForEfi(drive);
-    }
-
-    connect(ui->driveDropdown, &QComboBox::currentTextChanged, this,
-            [this](const QString &text) {
-                if (currentId() == 1 && !text.isEmpty() && text != "No drives found")
-                    populatePartitionTable(text.mid(5));
-    });
-      
-            setWizardButtonEnabled(QWizard::NextButton, true);
-            prepareForEfi(drive);
-
-    if (!drive.isEmpty())
-        prepareForEfi(drive);
-
-    connect(ui->driveDropdown, &QComboBox::currentTextChanged, this, [this](const QString &text) {
-        if (currentId() == 1 && !text.isEmpty() && text != "No drives found")
-            populatePartitionTable(text.mid(5));
-    });
-
-            setWizardButtonEnabled(QWizard::NextButton, false);
-            prepareForEfi(drive);
+        }
     });
 
     connect(ui->driveDropdown, &QComboBox::currentTextChanged, this,
             [this](const QString &text) {
                 if (currentId() == 1 && !text.isEmpty() && text != "No drives found")
                     populatePartitionTable(text.mid(5));
-     });
+            });
 }
 
 QString Installwizard::getUserHome() {
@@ -226,11 +206,6 @@ void Installwizard::setWizardButtonEnabled(QWizard::WizardButton which, bool ena
         btn->setEnabled(enabled);
 }
 
-void Installwizard::setButtonEnabled(QWizard::WizardButton which, bool enabled) {
-    if (QAbstractButton *btn = button(which))
-        btn->setEnabled(enabled);
-}
-
 void Installwizard::installDependencies() {
 
 
@@ -296,8 +271,8 @@ void Installwizard::installDependencies() {
 QStringList Installwizard::getAvailableDrives() {
     QProcess process;
 
-    // Use full path to lsblk
-    process.start("/usr/bin/lsblk", QStringList() << "-o" << "NAME,SIZE,TYPE" << "-d" << "-n");
+    // Use lsblk from PATH for better portability
+    process.start("lsblk", QStringList() << "-o" << "NAME,SIZE,TYPE" << "-d" << "-n");
     process.waitForFinished();
 
     QString output = process.readAllStandardOutput();
@@ -380,7 +355,7 @@ void Installwizard::forceUnmount(const QString &mountPoint) {
 
 void Installwizard::unmountDrive(const QString &drive) {
     QProcess process;
-    process.start("/usr/bin/lsblk",
+    process.start("lsblk",
                   QStringList() << "-nr" << "-o" << "MOUNTPOINT" << QString("/dev/%1").arg(drive));
     process.waitForFinished();
     QStringList points = QString(process.readAllStandardOutput()).split('\n', Qt::SkipEmptyParts);
@@ -435,9 +410,9 @@ void Installwizard::populatePartitionTable(const QString &drive) {
 
     QProcess process;
     QString device = QString("/dev/%1").arg(drive);
-    process.start("/usr/bin/lsblk",
-                  QStringList() << "-r" << "-n" << "-o"
-                                << "NAME,SIZE,TYPE,MOUNTPOINT" << device);
+    process.start("lsblk",
+                  QStringList() << "-r" << "-n" << "-o" <<
+                                "NAME,SIZE,TYPE,MOUNTPOINT" << device);
     process.waitForFinished();
     QString output = process.readAllStandardOutput();
 
@@ -463,7 +438,7 @@ void Installwizard::prepareForEfi(const QString &drive) {
     QString device = QString("/dev/%1").arg(drive);
 
     // Ensure the disk uses GPT so the ESP can be named
-    process.start("/usr/bin/lsblk", QStringList() << "-no" << "PTTYPE" << device);
+    process.start("lsblk", QStringList() << "-no" << "PTTYPE" << device);
     process.waitForFinished();
     QString type = QString(process.readAllStandardOutput()).trimmed();
     if (type != "gpt") {
@@ -481,7 +456,7 @@ void Installwizard::prepareForEfi(const QString &drive) {
     }
 
     // Determine next free region using parted
-    process.start("/usr/sbin/parted", QStringList() << "-sm" << device << "unit" << "MiB" << "print" << "free");
+    process.start("parted", QStringList() << "-sm" << device << "unit" << "MiB" << "print" << "free");
     process.waitForFinished();
     QString out = process.readAllStandardOutput();
 

--- a/Installwizard.h
+++ b/Installwizard.h
@@ -42,7 +42,6 @@ private:
     void mountISO();
     void installArchBase(const QString &selectedDrive);
     void installGrub(const QString &drive);
-    void setButtonEnabled(QWizard::WizardButton which, bool enabled);
     void setWizardButtonEnabled(QWizard::WizardButton which, bool enabled);
 };
 


### PR DESCRIPTION
## Summary
- clean up constructor signal hookups
- remove unused `setButtonEnabled` helper
- ensure EFI preparation button triggers partition creation
- use `lsblk` and `parted` from PATH so the EFI prep button works reliably

## Testing
- `qmake ArchHelp.pro` *(fails: command not found)*
- `make -j$(nproc)` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685dac0ab4a88332a64e9be3d2ad77d6